### PR TITLE
Add BuildInfo

### DIFF
--- a/rest/build.gradle.kts
+++ b/rest/build.gradle.kts
@@ -45,6 +45,12 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     }
 }
 
+// Populate Gradle properties in application.properties:
+// https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto-automatic-expansion
 tasks.withType<ProcessResources> {
     expand(project.properties)
+}
+
+springBoot {
+    buildInfo()
 }

--- a/rest/build.gradle.kts
+++ b/rest/build.gradle.kts
@@ -45,12 +45,6 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     }
 }
 
-// Populate Gradle properties in application.properties:
-// https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto-automatic-expansion
-tasks.withType<ProcessResources> {
-    expand(project.properties)
-}
-
 springBoot {
     buildInfo()
 }

--- a/rest/src/main/resources/application.properties
+++ b/rest/src/main/resources/application.properties
@@ -1,7 +1,0 @@
-# https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto-automatic-expansion
-# Gradle project properties are being expanded into this file, for the benefit of the next lines.
-# To use Spring property placeholders, they must be escaped: \${..}
-
-info.app.name=${name}
-info.app.version=${version}
-info.app.group=${group}

--- a/rest/src/main/resources/application.properties
+++ b/rest/src/main/resources/application.properties
@@ -1,3 +1,7 @@
+# https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto-automatic-expansion
+# Gradle project properties are being expanded into this file, for the benefit of the next lines.
+# To use Spring property placeholders, they must be escaped: \${..}
+
 info.app.name=${name}
 info.app.version=${version}
 info.app.group=${group}


### PR DESCRIPTION
Spring Boot autoconfigures a `BuildInfoContributor`:
https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-application-info-autoconfigure

Rather than using Gradle's Java `ProcessResources` task, use Spring Boot's Gradle plugin task:
https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/html/#integrating-with-actuator-build-info

This automatically adds BuildInfo to the `/actuator/info` endpoint, plus I can remove Gradle's properties inside application.properties, which also forces you to escape Spring Property Placeholder syntax.
https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto-automatic-expansion