### PR TITLE
Silence Gradle warnings

### DIFF
--- a/rest/build.gradle.kts
+++ b/rest/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("org.springframework.boot")
     id("io.spring.dependency-management")
 
-    id("com.gorylenko.gradle-git-properties") version "2.2.0"
+    id("com.gorylenko.gradle-git-properties") version "2.2.2"
     kotlin("jvm")
     kotlin("plugin.spring")
 

--- a/swagger/build.gradle.kts
+++ b/swagger/build.gradle.kts
@@ -3,7 +3,7 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
     id("io.spring.dependency-management")
-    id("org.hidetake.swagger.generator") version "2.18.1"
+    id("org.hidetake.swagger.generator") version "2.18.2"
     `java-library`
 }
 


### PR DESCRIPTION
Update Gradle plugins so Gradle no longer emits warnings about deprecated behavior.